### PR TITLE
Also dump muscle activations as <stem>_act.bin

### DIFF
--- a/qforce_tendon.cpp
+++ b/qforce_tendon.cpp
@@ -541,8 +541,10 @@ int main(int argc, const char** argv) {
     // Iterate through trajectory
     printf("Processing trajectory with %zu points...\n", trajectory_data.size());
     
-    // Collect all controls
+    // Collect all controls and per-step activation state (pre-mj_step,
+    // matching the convention used by get_ctrl at line 401).
     std::vector<std::vector<double>> all_ctrl;
+    std::vector<std::vector<double>> all_act;
     
     // Progress tracking
     size_t progress_interval = std::max(1UL, trajectory_data.size() / 100);  // Show progress every 1% or at least every point
@@ -565,7 +567,14 @@ int main(int argc, const char** argv) {
         
         // Store control
         all_ctrl.push_back(ctrl);
-        
+
+        // Capture activation state at time t (before mj_step). Row i in
+        // all_act / all_ctrl together describes the actuator state used
+        // to advance toward target_qpos[i+1].
+        std::vector<double> act_t(m->nu);
+        for (int j = 0; j < m->nu; j++) act_t[j] = d->act[j];
+        all_act.push_back(act_t);
+
         // Apply control to simulation
         for (int j = 0; j < m->nu; j++) {
             d->ctrl[j] = ctrl[j];
@@ -602,6 +611,25 @@ int main(int argc, const char** argv) {
         printf("Saved %zu control vectors to %s\n", all_ctrl.size(), output_filename.c_str());
     } else {
         printf("Failed to open %s for writing\n", output_filename.c_str());
+    }
+
+    // Save activations to sibling _act.bin (same header format).
+    std::string act_filename = std::string(output_path) + "/" + base_name + "_act.bin";
+    FILE* act_file = fopen(act_filename.c_str(), "wb");
+    if (act_file) {
+        size_t num_vectors = all_act.size();
+        size_t vector_size = m->nu;
+        fwrite(&num_vectors, sizeof(size_t), 1, act_file);
+        fwrite(&vector_size, sizeof(size_t), 1, act_file);
+
+        for (const auto& act : all_act) {
+            fwrite(act.data(), sizeof(double), act.size(), act_file);
+        }
+
+        fclose(act_file);
+        printf("Saved %zu activation vectors to %s\n", all_act.size(), act_filename.c_str());
+    } else {
+        printf("Failed to open %s for writing\n", act_filename.c_str());
     }
 
     // Cleanup


### PR DESCRIPTION
## Summary

The pipeline previously serialised only `ctrl`. This adds a sibling `<stem>_act.bin` per recording with the same header layout, holding the per-step muscle activation state.

This unblocks downstream training that needs the biophysically grounded activation latent (the factored architecture in the emg2orca CoRL 2026 submission). Without it, only the tendon control signal is available, which forces a self-supervised fallback that loses the muscle-grounding contribution.

## What changed

- Declare `all_act` alongside `all_ctrl` in main().
- Inside the per-step trajectory loop, capture `d->act` into `all_act` immediately after `all_ctrl.push_back(ctrl)` and **before** `mj_step` — mirroring the convention `get_ctrl` already uses internally at line 401.
- After the existing `ctrl` write block, write `<output>/<base>_act.bin` with the same `(size_t num_vectors, size_t vector_size, doubles...)` layout.

Total: 30 added / 2 removed in `qforce_tendon.cpp`. No change to existing `ctrl` output.

## Why pre-step

Row `i` in the two files now jointly describes the actuator state at time `i` that was used to drive the simulation toward `target_qpos[i+1]`. Capturing post-`mj_step` would shift the activation by one step and silently change the supervision target downstream.

## Test plan

- [x] Clean build against current toolchain (hdf5 2.1.1, mujoco 3.3.3).
- [x] Smoke-test on `emg2pose_dataset_mini/...recording-1_left.hdf5` — 142,674 ctrl + 142,674 act vectors written, both `vec_size=39`, values in `[0, 1]`, both files exactly 44,514,304 B (header + 142,674 × 39 × 8).
- [ ] Reviewer to confirm activation timing convention is what we want for the downstream training pipeline.